### PR TITLE
Add render-drawio-action for automatically rendering .drawio files

### DIFF
--- a/.github/workflows/drawio-render.yml
+++ b/.github/workflows/drawio-render.yml
@@ -24,3 +24,4 @@ jobs:
           author_email: 41898282+github-actions[bot]@users.noreply.github.com
           message: 'Automatically render .drawio files'
           add: "${{ steps.render.outputs.rendered-files }}"
+        if: "${{ steps.render.outputs.rendered-files != ''}}"

--- a/.github/workflows/drawio-render.yml
+++ b/.github/workflows/drawio-render.yml
@@ -8,9 +8,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Render draw.io files
-        uses: ghcr.io/racklet/render-drawio-action@v1
+        uses: docker://ghcr.io/racklet/render-drawio-action:v1
         id: render
-        with: # Showcasing the default values here
+        with:
           formats: 'svg' # Render all as SVG
           sub-dirs: 'docs' # Render only drawings in docs
           skip-dirs: '.git' # Always skip the .git directory

--- a/.github/workflows/drawio-render.yml
+++ b/.github/workflows/drawio-render.yml
@@ -1,3 +1,5 @@
+name: Render draw.io files
+
 on: [push]
 
 jobs:

--- a/.github/workflows/drawio-render.yml
+++ b/.github/workflows/drawio-render.yml
@@ -1,0 +1,26 @@
+on: [push]
+
+jobs:
+  render_drawio:
+    runs-on: ubuntu-latest
+    name: Render draw.io files
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Render draw.io files
+        uses: ghcr.io/racklet/render-drawio-action@v1
+        id: render
+        with: # Showcasing the default values here
+          formats: 'svg' # Render all as SVG
+          sub-dirs: 'docs' # Render only drawings in docs
+          skip-dirs: '.git' # Always skip the .git directory
+          log-level: 'info' # Info level logging
+      - name: Print the rendered files
+        run: 'echo "The following files were generated: ${{ steps.render.outputs.rendered-files }}"'
+      - uses: EndBug/add-and-commit@v7
+        with:
+          # This "special" author name and email will show up as the GH Actions user/bot in the UI
+          author_name: github-actions
+          author_email: 41898282+github-actions[bot]@users.noreply.github.com
+          message: 'Automatically render .drawio files'
+          add: "${{ steps.render.outputs.rendered-files }}"


### PR DESCRIPTION
This adds https://github.com/racklet/render-drawio-action and configures it to automatically render all `.drawio` files under `docs` on push. Let's see if we can get this working.

cc @luxas @chiplet 