### PR TITLE
Update the draw.io rendering GH Action

### DIFF
--- a/.github/workflows/drawio-render.yml
+++ b/.github/workflows/drawio-render.yml
@@ -10,15 +10,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Render draw.io files
-        uses: docker://ghcr.io/racklet/render-drawio-action:v1
+        uses: docker://ghcr.io/racklet/render-drawio-action:v1.0.3
         id: render
         with:
           formats: 'svg' # Render all as SVG
           sub-dirs: 'docs' # Render only drawings in docs
           skip-dirs: '.git' # Always skip the .git directory
           log-level: 'info' # Info level logging
-      - name: Print the rendered files
-        run: 'echo "The following files were generated: ${{ steps.render.outputs.rendered-files }}"'
+      - name: List the rendered files
+        run: 'ls -l ${{ steps.render.outputs.rendered-files }}'
       - uses: EndBug/add-and-commit@v7
         with:
           # This "special" author name and email will show up as the GH Actions user/bot in the UI


### PR DESCRIPTION
Going to [v1.0.3](https://github.com/racklet/render-drawio-action/releases/tag/v1.0.3) brings many important fixes, particularly around relative file path output for `add-and-commit` as well as support for paths/filenames with whitespace.